### PR TITLE
Use crmUrl helper function, add slash

### DIFF
--- a/ang/afsearchCommitteeAppointments.aff.html
+++ b/ang/afsearchCommitteeAppointments.aff.html
@@ -1,6 +1,6 @@
 <div af-fieldset="" class="contact-profile-appointment">
 	<div class="af-markup">
-		<p><a class="btn btn-primary add-appointment" target="crm-popup" href="/wp-admin/admin.php?page=CiviCRM&amp;q=civicrm%2Fcommittee%2fappointment%2Fmanage#?contact_id={{options.contact_id}}">Add Committee Appointment</a></p>
+		<p><a class="btn btn-primary add-appointment" target="crm-popup" href="{{ crmUrl('civicrm/committee/appointment/manage#/?contact_id=' + options.contact_id) }}">Add Committee Appointment</a></p>
 		<p>&nbsp;</p>
 	</div>
 	<crm-search-display-table search-name="Committee_Appointments" display-name="Contact_Committee_Appointments" filters="{contact_id: options.contact_id}"></crm-search-display-table>


### PR DESCRIPTION
This uses a helper function to avoid wordpress-specific url construction. It also adds a slash after the hash which is required by Afform.